### PR TITLE
docker-compose correcto

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,8 @@
 version: '3'
 services:
-  db:
-    image: contemporanica/bbdd:Definitivo
-    container_name: db
+  dbcontemporanica:
+    image: contemporanica/bbdd:latest
+    container_name: dbcontemporanica
     restart: always
     environment:
       MYSQL_ROOT_PASSWORD: ContemporanicaDaw2@23
@@ -10,20 +10,21 @@ services:
       MYSQL_USER: contemporanica
       MYSQL_PASSWORD: ContemporanicaDaw2@23
     ports:
-      - "3307:3306"
+      - "3306:3306"
     volumes:
       - db_data:/var/lib/mysql
-  api:
+  apicontemporanica:
     image: contemporanica/api:latest
+    container_name: apicontemporanica
     ports:
       - "4000:4000"
     depends_on:
-      - db
+      - dbcontemporanica
     environment:
-      DB_HOST: db
+      DB_HOST: dbcontemporanica
       DB_USER: contemporanica
       DB_PASSWORD: ContemporanicaDaw2@23
-      DB_PORT: "3307"
+      DB_PORT: "3306"
       TOKEN: a944114ba4149684eb4e6b00e6093fdb
 volumes:
   db_data:


### PR DESCRIPTION
No os lo vais a creer, pero al poner el puerto del mysql otra vez al 3306 ha vuelto a funcionar. No se si el contenedor de mysql tiene el firewall activado o que mierdas, pero funciona en mi equipo y no da el error de conexión rechazada.

 @JefferyCE cuqndo puedas prueba el docker compose en el server.

yo lo que haria en el server es:

crear una carpeta contemporanica y allí poner el docker compose y lanzar el docker-compose up -d

una vez, mira los logs del cotnenedor de la api y dinos si da un error de conexión a la bbdd. (que creo que no lo dará).

Es probable, que aunque tengamos el api levantada en el puerto 4000, no lo podamos ver desde el dominio ya que no @JefferyCE  tendrá que habilitar ese puerto en el firewall de azure. Ya me vais contando.

FYI:
@Caastan @alemartagon @RobertoRodriguezNunez @PaulaHidalgo1 @anabel17gr 